### PR TITLE
fix code actions

### DIFF
--- a/ocaml-lsp-server/src/compl.ml
+++ b/ocaml-lsp-server/src/compl.ml
@@ -79,8 +79,8 @@ let prefix_of_position ~short_path source position =
             not short_path
           | _ -> false
       in
-      String.sub text ~pos:from ~len:(String.length text - from) |>
-      String.rfindi ~f:(fun c -> not (is_prefix_char c))
+      String.sub text ~pos:0 ~len:from
+      |> String.rfindi ~f:(fun c -> not (is_prefix_char c))
     in
     let pos =
       match pos with
@@ -126,7 +126,7 @@ let suffix_of_position source position =
           |> String.findi ~f:(fun c -> not (ident_char c))
           |> Option.value ~default:len
         in
-        until - from
+        until
       in
       String.sub text ~pos:from ~len
 


### PR DESCRIPTION
This PR fixes a regression introduced when rebasing, making code actions fail.
(`String.sub` was called with wrong arguments, making it raise, and no code action or completions were proposed to the user)